### PR TITLE
Added in Manifold.js 

### DIFF
--- a/tools/apps.md
+++ b/tools/apps.md
@@ -29,6 +29,7 @@
 
 * [ionic](http://ionicframework.com/)
 * [onsen.io](http://onsen.io/)
+* [manifold.js](http://manifoldjs.com/)
 
 ##### Cordova mobile development environments/platforms/tools:
 


### PR DESCRIPTION
Added in Manifold.js as a hosted application tool that defaults or used Cordova to polyfill. 
