### PR TITLE
Update error.md to reflect Sentry can be self-hosted

### DIFF
--- a/tools/error.md
+++ b/tools/error.md
@@ -2,7 +2,7 @@
 
 * [Raygun](https://raygun.io) [$]
 * [errorception](https://errorception.com/) [$]
-* [sentry](https://getsentry.com/welcome/) [$]
+* [Sentry](https://getsentry.com/welcome/) [$ or free for self-hosted]
 * [{track:js}](https://trackjs.com/) [$]
 
 


### PR DESCRIPTION
Sentry is open source and can be installed / self-hosted for free: https://github.com/getsentry/sentry
