### PR TITLE
Corrected link format, title, and reordered

### DIFF
--- a/practice/interview-q.md
+++ b/practice/interview-q.md
@@ -2,12 +2,12 @@
 
 Questions you may get asked:
 
-* [Front-end Job Interview Questions](http://h5bp.github.io/Front-end-Developer-Interview-Questions/)
-* [Interview Questions for front-end-Developer](http://thatjsdude.com/interview/index.html)
 * [10 Interview Questions
 Every JavaScript Developer Should Know](https://medium.com/javascript-scene/10-interview-questions-every-javascript-developer-should-know-6fa6bdf5ad95)
-*[Front End Quiz](http://davidshariff.com/quiz/)
-*[Javascript Quiz](http://davidshariff.com/js-quiz/)
+* [Front-end Job Interview Questions](http://h5bp.github.io/Front-end-Developer-Interview-Questions/)
+* [Front End Web Development Quiz](http://davidshariff.com/quiz/)
+* [Interview Questions for front-end-Developer](http://thatjsdude.com/interview/index.html)
+* [JavaScript Web Quiz](http://davidshariff.com/js-quiz/)
 
 Questions you ask:
 


### PR DESCRIPTION
The links to quizzes weren’t formatted correctly so they didn’t display on their own bulleted line. I fixed that, updated the link title to match David Shariff’s quiz names, then reordered alphabetically.
