### PR TITLE
fix URL for intern testing framework

### DIFF
--- a/tools/testing.md
+++ b/tools/testing.md
@@ -1,6 +1,6 @@
 # Testing framework tools 
 
-* [Intern](https://www.contentful.com/)
+* [Intern](https://theintern.github.io/)
 * [Karma](http://karma-runner.github.io/0.8/index.html)
 
 


### PR DESCRIPTION
The URL for the Intern testing framework pointed to [https://www.contentful.com/](https://www.contentful.com/) instead of [https://theintern.github.io/](https://theintern.github.io/).
