### PR TITLE
Added clarification for same-name links

### DIFF
--- a/learning/accessibility.md
+++ b/learning/accessibility.md
@@ -6,7 +6,9 @@
 >
 >Accessibility is not to be confused with usability, which is the extent to which a product (such as a device, service, or environment) can be used by specified users to achieve specified goals with effectiveness, efficiency and satisfaction in a specified context of use.
 >
->Accessibility is strongly related to universal design which is the process of creating products that are usable by people with the widest possible range of abilities, operating within the widest possible range of situations. This is about making things accessible to all people (whether they have a disability or not). &#8212; [Wikipedia](https://en.wikipedia.org/wiki/Accessibility)
+>Accessibility is strongly related to universal design which is the process of creating products that are usable by people with the widest possible range of abilities, operating within the widest possible range of situations. This is about making things accessible to all people (whether they have a disability or not).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Accessibility)</cite>
 
 ##### General Learning:
 

--- a/learning/accessibility.md
+++ b/learning/accessibility.md
@@ -6,13 +6,13 @@
 >
 >Accessibility is not to be confused with usability, which is the extent to which a product (such as a device, service, or environment) can be used by specified users to achieve specified goals with effectiveness, efficiency and satisfaction in a specified context of use.
 >
->Accessibility is strongly related to universal design which is the process of creating products that are usable by people with the widest possible range of abilities, operating within the widest possible range of situations. This is about making things accessible to all people (whether they have a disability or not). - wikipedia
+>Accessibility is strongly related to universal design which is the process of creating products that are usable by people with the widest possible range of abilities, operating within the widest possible range of situations. This is about making things accessible to all people (whether they have a disability or not). &#8212; [Wikipedia](https://en.wikipedia.org/wiki/Accessibility)
 
 ##### General Learning:
 
 * [Foundations of UX: Accessibility](http://www.lynda.com/Accessibility-tutorials/Foundations-UX-Accessibility/435008-2.html) [watch][$]
-* [Introduction to Web Accessibility](https://webaccessibility.withgoogle.com/course) [watch]
-* [Introduction to Web Accessibility](https://www.w3.org/WAI/intro/accessibility.php) [read]
+* [Introduction to Web Accessibility](https://webaccessibility.withgoogle.com/course) - Google Open Online Education [watch]
+* [Introduction to Web Accessibility](https://www.w3.org/WAI/intro/accessibility.php) - WAI [read]
 * [Universal Design for Web Applications: Web Applications That Reach Everyone](http://www.amazon.com/Universal-Design-Web-Applications-Everyone/dp/0596518730/ref=sr_1_1) [read][$]
 * [Web Accessibility: Getting Started](http://www.pluralsight.com/courses/web-accessibility-getting-started) [watch][$]
 * [A Web for Everyone](http://rosenfeldmedia.com/books/a-web-for-everyone/) [read][$]

--- a/learning/browser-dev-tools.md
+++ b/learning/browser-dev-tools.md
@@ -4,7 +4,9 @@
 >
 > Web development tools come as browser add-ons or built in features in web browsers. The most popular web browsers today like, Google Chrome, Firefox, Opera, Internet Explorer, and Safari have built in tools to help web developers, and many additional add-ons can be found in their respective plugin download centers.
 >
-> Web development tools allow developers to work with a variety of web technologies, including HTML, CSS, the DOM, JavaScript, and other components that are handled by the web browser. Due to the increasing demand from web browsers to do more popular web browsers have included more features geared for developers. - wikipedia
+> Web development tools allow developers to work with a variety of web technologies, including HTML, CSS, the DOM, JavaScript, and other components that are handled by the web browser. Due to the increasing demand from web browsers to do more popular web browsers have included more features geared for developers.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Web_development_tools)</cite>
 
 While most browsers come equipped with web developer tools, the [Chrome developer tools](https://developers.google.com/web/tools/chrome-devtools/) are currently the most talked about and widely used tools available.
 

--- a/learning/browsers.md
+++ b/learning/browsers.md
@@ -1,6 +1,8 @@
 # Learn Web Browsers
 
-> A web browser (commonly referred to as a browser) is a software application for retrieving, presenting, and traversing information resources on the World Wide Web. An information resource is identified by a Uniform Resource Identifier (URI/URL) and may be a web page, image, video or other piece of content. Hyperlinks present in resources enable users easily to navigate their browsers to related resources. Although browsers are primarily intended to use the World Wide Web, they can also be used to access information provided by web servers in private networks or files in file systems. - Wikipedia
+> A web browser (commonly referred to as a browser) is a software application for retrieving, presenting, and traversing information resources on the World Wide Web. An information resource is identified by a Uniform Resource Identifier (URI/URL) and may be a web page, image, video or other piece of content. Hyperlinks present in resources enable users easily to navigate their browsers to related resources. Although browsers are primarily intended to use the World Wide Web, they can also be used to access information provided by web servers in private networks or files in file systems.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Web_browser)</cite>
 
 
 ##### The [most commonly used browsers](http://www.sitepoint.com/browser-trends-april-2015-statcounter-vs-netmarketshare/) (on any device) are:
@@ -12,7 +14,7 @@
 
 ![](../images/statcounter.png "http://gs.statcounter.com/#all-browser_version_partially_combined-ww-monthly-201408-201508-bar")
 
-<cite>image source: <a href="http://gs.statcounter.com/#all-browser_version_partially_combined-ww-monthly-201408-201508-bar">http://gs.statcounter.com/#all-browser_version_partially_combined-ww-monthly-201408-201508-bar</a></cite>
+<cite>Image source: <a href="http://gs.statcounter.com/#all-browser_version_partially_combined-ww-monthly-201408-201508-bar">http://gs.statcounter.com/#all-browser_version_partially_combined-ww-monthly-201408-201508-bar</a></cite>
 
 ##### Evolution of Browsers & Web Technologies (i.e., APIs)
 
@@ -35,7 +37,7 @@
 
 ![](../images/browsers-work.png "http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/")
 
-<cite>image source: <a href="http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/">http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/</a></cite>
+<cite>Image source: <a href="http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/">http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/</a></cite>
 
 ##### Optimizing for Browsers:
 

--- a/learning/build.md
+++ b/learning/build.md
@@ -1,6 +1,8 @@
 # Learn Build and Task Automation
 
-> Build automation is the process of automating the creation of a software build and the associated processes including: compiling computer source code into binary code, packaging binary code, and running automated tests. - wikipedia
+> Build automation is the process of automating the creation of a software build and the associated processes including: compiling computer source code into binary code, packaging binary code, and running automated tests.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Build_automation)</cite>
 
 ##### General Learning:
 
@@ -13,7 +15,7 @@
 
 ##### References/Docs:
 
-* [gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
+* [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
 
 Gulp is great. However, you might only need `npm run`. Before turning to additional complexity in your application stack ask yourself if `npm run` can do the job. If you need more, use both. 
 

--- a/learning/cli.md
+++ b/learning/cli.md
@@ -1,6 +1,8 @@
 # Learn Command Line
 
-> A command-line interface or command language interpreter (CLI), also known as command-line user interface, console user interface, and character user interface (CUI), is a means of interacting with a computer program where the user (or client) issues commands to the program in the form of successive lines of text (command lines). - wikipedia
+> A command-line interface or command language interpreter (CLI), also known as command-line user interface, console user interface, and character user interface (CUI), is a means of interacting with a computer program where the user (or client) issues commands to the program in the form of successive lines of text (command lines).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Command-line_interface)</cite>
 
 ##### General Learning:
 

--- a/learning/dns.md
+++ b/learning/dns.md
@@ -1,10 +1,12 @@
 # Learn Domain Name System (aka DNS)
 
-> The Domain Name System (DNS) is a hierarchical distributed naming system for computers, services, or any resource connected to the Internet or a private network. It associates various information with domain names assigned to each of the participating entities. Most prominently, it translates domain names, which can be easily memorized by humans, to the numerical IP addresses needed for the purpose of computer services and devices worldwide. The Domain Name System is an essential component of the functionality of most Internet services because it is the Internet's primary directory service. - wikipedia
+> The Domain Name System (DNS) is a hierarchical distributed naming system for computers, services, or any resource connected to the Internet or a private network. It associates various information with domain names assigned to each of the participating entities. Most prominently, it translates domain names, which can be easily memorized by humans, to the numerical IP addresses needed for the purpose of computer services and devices worldwide. The Domain Name System is an essential component of the functionality of most Internet services because it is the Internet's primary directory service.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Domain_Name_System)</cite>
 
 ![](../images/dns.jpg "http://www.digital-digest.com/blog/DVDGuy/wp-content/uploads/2011/11/how_dns_works.jpg")
 
-<cite>image source: <a href="http://www.digital-digest.com/blog/DVDGuy/wp-content/uploads/2011/11/how_dns_works.jpg">http://www.digital-digest.com/blog/DVDGuy/wp-content/uploads/2011/11/how_dns_works.jpg</a></cite>
+<cite>Image source: <a href="http://www.digital-digest.com/blog/DVDGuy/wp-content/uploads/2011/11/how_dns_works.jpg">http://www.digital-digest.com/blog/DVDGuy/wp-content/uploads/2011/11/how_dns_works.jpg</a></cite>
 
 
 * [DNS Explained](https://www.youtube.com/watch?v=72snZctFFtA) [watch]

--- a/learning/dom.md
+++ b/learning/dom.md
@@ -1,10 +1,16 @@
 # Learn DOM, BOM, & jQuery
 
-> **DOM** - The Document Object Model (DOM) is a cross-platform and language-independent convention for representing and interacting with objects in HTML, XHTML, and XML documents. The nodes of every document are organized in a tree structure, called the DOM tree. Objects in the DOM tree may be addressed and manipulated by using methods on the objects. The public interface of a DOM is specified in its application programming interface (API). - wikipedia.org
+> **DOM** - The Document Object Model (DOM) is a cross-platform and language-independent convention for representing and interacting with objects in HTML, XHTML, and XML documents. The nodes of every document are organized in a tree structure, called the DOM tree. Objects in the DOM tree may be addressed and manipulated by using methods on the objects. The public interface of a DOM is specified in its application programming interface (API).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Document_Object_Model)</cite>
  
-> **BOM** - The Browser Object Model (BOM) is a browser-specific convention referring to all the objects exposed by the web browser. Unlike the Document Object Model, there is no standard for implementation and no strict definition, so browser vendors are free to implement the BOM in any way they wish. - wikipedia.org
+> **BOM** - The Browser Object Model (BOM) is a browser-specific convention referring to all the objects exposed by the web browser. Unlike the Document Object Model, there is no standard for implementation and no strict definition, so browser vendors are free to implement the BOM in any way they wish.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Browser_Object_Model)</cite>
  
-> **jQuery** - jQuery is a cross-platform JavaScript library designed to simplify the client-side scripting of HTML. jQuery is the most popular JavaScript library in use today, with installation on 65% of the top 10 million highest-trafficked sites on the Web. jQuery is free, open-source software licensed under the MIT License. - wikipedia.org
+> **jQuery** - jQuery is a cross-platform JavaScript library designed to simplify the client-side scripting of HTML. jQuery is the most popular JavaScript library in use today, with installation on 65% of the top 10 million highest-trafficked sites on the Web. jQuery is free, open-source software licensed under the MIT License.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JQuery)</cite>
 
 The ideal path, but certainly the most difficult, would be to first learn JavaScript, then the DOM, then jQuery. However, do what makes sense to your brain. Most front-end developers learn about JavaScript and then DOM by way of first learning jQuery. Whatever path you take, just make sure JavaScript, then DOM, or jQuery don't become a black box.
 

--- a/learning/fonts.md
+++ b/learning/fonts.md
@@ -2,7 +2,9 @@
 
 > Web typography refers to the use of fonts on the World Wide Web. When HTML was first created, font faces and styles were controlled exclusively by the settings of each Web browser. There was no mechanism for individual Web pages to control font display until Netscape introduced the `<font>` tag in 1995, which was then standardized in the HTML 3.2 specification. However, the font specified by the tag had to be installed on the user's computer or a fallback font, such as a browser's default sans-serif or monospace font, would be used. The first Cascading Style Sheets specification was published in 1996 and provided the same capabilities.
 > 
-> The CSS2 specification was released in 1998 and attempted to improve the font selection process by adding font matching, synthesis and download. These techniques did not gain much use, and were removed in the CSS2.1 specification. However, Internet Explorer added support for the font downloading feature in version 4.0, released in 1997.[1] Font downloading was later included in the CSS3 fonts module, and has since been implemented in Safari 3.1, Opera 10 and Mozilla Firefox 3.5. This has subsequently increased interest in Web typography, as well as the usage of font downloading. - wikipedia
+> The CSS2 specification was released in 1998 and attempted to improve the font selection process by adding font matching, synthesis and download. These techniques did not gain much use, and were removed in the CSS2.1 specification. However, Internet Explorer added support for the font downloading feature in version 4.0, released in 1997. Font downloading was later included in the CSS3 fonts module, and has since been implemented in Safari 3.1, Opera 10 and Mozilla Firefox 3.5. This has subsequently increased interest in Web typography, as well as the usage of font downloading.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Web_typography)</cite>
 
 ##### General Learning:
 

--- a/learning/headless-browsers.md
+++ b/learning/headless-browsers.md
@@ -2,7 +2,9 @@
 
 > A headless browser is a web browser without a graphical user interface.
 >
->Headless browsers provide automated control of a web page in an environment similar to popular web browsers, but are executed via a command line interface or using network communication. They are particularly useful for testing web pages as they are able to render and understand HTML the same way a browser would, including styling elements such as page layout, color, font selection and execution of JavaScript and AJAX which are usually not available when using other testing methods. Google stated in 2009 that using a headless browser could help their search engine index content from websites that use AJAX. - wikipedia
+>Headless browsers provide automated control of a web page in an environment similar to popular web browsers, but are executed via a command line interface or using network communication. They are particularly useful for testing web pages as they are able to render and understand HTML the same way a browser would, including styling elements such as page layout, color, font selection and execution of JavaScript and AJAX which are usually not available when using other testing methods. Google stated in 2009 that using a headless browser could help their search engine index content from websites that use AJAX.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Headless_browser)</cite>
 
 * [Getting Started with PhantomJS](http://www.amazon.com/Getting-Started-PhantomJS-Aries-Beltran/dp/1782164227) [read][$]
 * [PhantomJS Cookbook](http://www.amazon.com/PhantomJS-Cookbook-Rob-Friesel/dp/178398192X) [read][$]

--- a/learning/hosting.md
+++ b/learning/hosting.md
@@ -1,10 +1,12 @@
 # Learn Web Hosting
 
-> A web hosting service is a type of Internet hosting service that allows individuals and organizations to make their website accessible via the World Wide Web. Web hosts are companies that provide space on a server owned or leased for use by clients, as well as providing Internet connectivity, typically in a data center. Web hosts can also provide data center space and connectivity to the Internet for other servers located in their data center, called colocation, also known as Housing in Latin America or France. - wikipedia
+> A web hosting service is a type of Internet hosting service that allows individuals and organizations to make their website accessible via the World Wide Web. Web hosts are companies that provide space on a server owned or leased for use by clients, as well as providing Internet connectivity, typically in a data center. Web hosts can also provide data center space and connectivity to the Internet for other servers located in their data center, called colocation, also known as Housing in Latin America or France.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Web_hosting_service)</cite>
 
 ![](../images/host.jpg "http://www.alphaelite.com.sg/sitev2/images/stories/webhostdemo.jpg")
 
-<cite>image source: <a href="http://www.alphaelite.com.sg/sitev2/images/stories/webhostdemo.jpg">http://www.alphaelite.com.sg/sitev2/images/stories/webhostdemo.jpg</a></cite>
+<cite>Image source: <a href="http://www.alphaelite.com.sg/sitev2/images/stories/webhostdemo.jpg">http://www.alphaelite.com.sg/sitev2/images/stories/webhostdemo.jpg</a></cite>
 
 
 ##### General Learning:

--- a/learning/html-css.md
+++ b/learning/html-css.md
@@ -1,8 +1,12 @@
 # Learn HTML & CSS
 
-> **HTML** - HyperText Markup Language, commonly referred to as HTML, is the standard markup language used to create web pages.[1] Web browsers can read HTML files and render them into visible or audible web pages. HTML describes the structure of a website semantically along with cues for presentation, making it a markup language, rather than a programming language. - wikipedia.org
+> **HTML** - HyperText Markup Language, commonly referred to as HTML, is the standard markup language used to create web pages. Web browsers can read HTML files and render them into visible or audible web pages. HTML describes the structure of a website semantically along with cues for presentation, making it a markup language, rather than a programming language.
 
-> **CSS** - Cascading Style Sheets (CSS) is a style sheet language used for describing the look and formatting of a document written in a markup language. Although most often used to change the style of web pages and user interfaces written in HTML and XHTML, the language can be applied to any kind of XML document, including plain XML, SVG and XUL. Along with HTML and JavaScript, CSS is a cornerstone technology used by most websites to create visually engaging webpages, user interfaces for web applications, and user interfaces for many mobile applications. - wikipedia.org
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/HTML)</cite>
+
+> **CSS** - Cascading Style Sheets (CSS) is a style sheet language used for describing the look and formatting of a document written in a markup language. Although most often used to change the style of web pages and user interfaces written in HTML and XHTML, the language can be applied to any kind of XML document, including plain XML, SVG and XUL. Along with HTML and JavaScript, CSS is a cornerstone technology used by most websites to create visually engaging webpages, user interfaces for web applications, and user interfaces for many mobile applications.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Cascading_Style_Sheets)</cite>
 
 Liken to constructing a house, one might consider HTML the framing and CSS to be the painting & decorating.
 

--- a/learning/http-networks.md
+++ b/learning/http-networks.md
@@ -1,10 +1,16 @@
 # Learn HTTP/Networks (Including CORS & WebSockets)
 
-> **HTTP** The Hypertext Transfer Protocol (HTTP) is an application protocol for distributed, collaborative, hypermedia information systems. HTTP is the foundation of data communication for the World Wide Web. - Wikipedia
+> **HTTP** - The Hypertext Transfer Protocol (HTTP) is an application protocol for distributed, collaborative, hypermedia information systems. HTTP is the foundation of data communication for the World Wide Web.
 
-> **CORS** Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources (e.g., fonts) on a web page to be requested from another domain outside the domain from which the resource originated. - Wikipedia
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)</cite>
+
+> **CORS** - Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources (e.g., fonts) on a web page to be requested from another domain outside the domain from which the resource originated.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)</cite>
   
->**WebSockets** WebSocket is a protocol providing full-duplex communication channels over a single TCP connection. The WebSocket protocol was standardized by the IETF as RFC 6455 in 2011, and the WebSocket API in Web IDL is being standardized by the W3C. - Wikipedia
+>**WebSockets** - WebSocket is a protocol providing full-duplex communication channels over a single TCP connection. The WebSocket protocol was standardized by the IETF as RFC 6455 in 2011, and the WebSocket API in Web IDL is being standardized by the W3C.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/WebSocket)</cite>
 
 ##### HTTP
 

--- a/learning/internet.md
+++ b/learning/internet.md
@@ -1,9 +1,11 @@
 # Learn Internet/Web
 
-> The Internet is a global system of interconnected computer networks that use the Internet protocol suite (TCP/IP) to link several billion devices worldwide. It is a network of networks that consists of millions of private, public, academic, business, and government networks of local to global scope, linked by a broad array of electronic, wireless, and optical networking technologies. The Internet carries an extensive range of information resources and services, such as the inter-linked hypertext documents and applications of the World Wide Web (WWW), electronic mail, telephony, and peer-to-peer networks for file sharing. - wikipedia
+> The Internet is a global system of interconnected computer networks that use the Internet protocol suite (TCP/IP) to link several billion devices worldwide. It is a network of networks that consists of millions of private, public, academic, business, and government networks of local to global scope, linked by a broad array of electronic, wireless, and optical networking technologies. The Internet carries an extensive range of information resources and services, such as the inter-linked hypertext documents and applications of the World Wide Web (WWW), electronic mail, telephony, and peer-to-peer networks for file sharing.
 
-* [How does the Internet work](http://www.w3.org/wiki/How_does_the_Internet_work) [read]
-* [How does the Internet Work?](http://web.stanford.edu/class/msande91si/www-spr04/readings/week1/InternetWhitepaper.htm) [read]
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Internet)</cite>
+
+* [How does the Internet work](http://www.w3.org/wiki/How_does_the_Internet_work) - W3C [read]
+* [How does the Internet Work?](http://web.stanford.edu/class/msande91si/www-spr04/readings/week1/InternetWhitepaper.htm) - Stanford Paper [read]
 * [How the Internet Works](https://www.khanacademy.org/partner-content/code-org/internet-works) [watch]
 * [How the Internet Works in 5 Minutes](https://www.youtube.com/watch?v=7_LPdttKXPc) [watch]
 * [How The Web Works](https://www.eventedmind.com/classes/how-the-web-works-7f40254c) [watch][$]

--- a/learning/javascript.md
+++ b/learning/javascript.md
@@ -1,6 +1,8 @@
 # Learn JavaScript
 
-> JavaScript is a high level, dynamic, untyped, and interpreted programming language. It has been standardized in the ECMAScript language specification. Alongside HTML and CSS, it is one of the three essential technologies of World Wide Web content production; the majority of websites employ it and it is supported by all modern web browsers without plug-ins. JavaScript is prototype-based with first-class functions, making it a multi-paradigm language, supporting object-oriented, imperative, and functional programming styles. It has an API for working with text, arrays, dates and regular expressions, but does not include any I/O, such as networking, storage or graphics facilities, relying for these upon the host environment in which it is embedded. - wikipedia.org
+> JavaScript is a high level, dynamic, untyped, and interpreted programming language. It has been standardized in the ECMAScript language specification. Alongside HTML and CSS, it is one of the three essential technologies of World Wide Web content production; the majority of websites employ it and it is supported by all modern web browsers without plug-ins. JavaScript is prototype-based with first-class functions, making it a multi-paradigm language, supporting object-oriented, imperative, and functional programming styles. It has an API for working with text, arrays, dates and regular expressions, but does not include any I/O, such as networking, storage or graphics facilities, relying for these upon the host environment in which it is embedded.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JavaScript)</cite>
 
 ##### General Learning:
 

--- a/learning/json.md
+++ b/learning/json.md
@@ -4,7 +4,9 @@
 >
 > Although originally derived from the JavaScript scripting language, JSON is a language-independent data format. Code for parsing and generating JSON data is readily available in many programming languages.
 > 
-> The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json. - wikipedia
+> The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JSON)</cite>
 
 ##### General Learning:
 

--- a/learning/multi-thing-dev.md
+++ b/learning/multi-thing-dev.md
@@ -2,7 +2,7 @@
 
 ![](../images/things.jpg "http://bradfrost.com/blog/post/this-is-the-web/")
 
-<cite>image source: <a href="http://bradfrost.com/blog/post/this-is-the-web/">http://bradfrost.com/blog/post/this-is-the-web/</a></cite>
+<cite>Image source: <a href="http://bradfrost.com/blog/post/this-is-the-web/">http://bradfrost.com/blog/post/this-is-the-web/</a></cite>
 
 A site or application can run on a wide range of computers, laptops, tablets and phones, as well as a handful of other things (watches, thermostats, fridges, etc.). How you determine what things you'll support and how you will develop to support those things is called a multi-thing development strategy. Below, I list the most common multi-thing development strategies.
 

--- a/learning/node.md
+++ b/learning/node.md
@@ -2,7 +2,9 @@
 
 > Node.js is an open-source, cross-platform runtime environment for developing server-side web applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on OS X, Microsoft Windows, Linux, FreeBSD, NonStop,[3] IBM AIX, IBM System z and IBM i. Its work is hosted and supported by the Node.js Foundation,[4] a collaborative project at Linux Foundation.[5] 
 > 
-> Node.js provides an event-driven architecture and a non-blocking I/O API designed to optimize an application's throughput and scalability for real-time web applications. It uses Google V8 JavaScript engine to execute code, and a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in library to allow applications to act as a web server without software such as Apache HTTP Server, Nginx or IIS. - wikipedia
+> Node.js provides an event-driven architecture and a non-blocking I/O API designed to optimize an application's throughput and scalability for real-time web applications. It uses Google V8 JavaScript engine to execute code, and a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in library to allow applications to act as a web server without software such as Apache HTTP Server, Nginx or IIS.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Node.js)</cite>
 
 ##### General Learning:
 

--- a/learning/package-manager.md
+++ b/learning/package-manager.md
@@ -1,6 +1,8 @@
 # Learn Package Manager
 
-> A package manager or package management system is a collection of software tools that automates the process of installing, upgrading, configuring, and removing software packages for a computer's operating system in a consistent manner. It typically maintains a database of software dependencies and version information to prevent software mismatches and missing prerequisites. - wikipedia
+> A package manager or package management system is a collection of software tools that automates the process of installing, upgrading, configuring, and removing software packages for a computer's operating system in a consistent manner. It typically maintains a database of software dependencies and version information to prevent software mismatches and missing prerequisites.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Package_manager)</cite>
 
 ##### General Learning:
 

--- a/learning/perf.md
+++ b/learning/perf.md
@@ -1,6 +1,8 @@
 # Learn Site Performance Optimization
 
-> Web performance optimization, WPO, or website optimization is the field of knowledge about increasing the speed in which web pages are downloaded and displayed on the user's web browser. With the average internet speed increasing globally, it is fitting for website administrators and webmasters to consider the time it takes for websites to render for the visitor. - wikipedia
+> Web performance optimization, WPO, or website optimization is the field of knowledge about increasing the speed in which web pages are downloaded and displayed on the user's web browser. With the average internet speed increasing globally, it is fitting for website administrators and webmasters to consider the time it takes for websites to render for the visitor.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Web_performance_optimization)</cite>
 
 ##### General Learning:
 

--- a/learning/seo.md
+++ b/learning/seo.md
@@ -1,6 +1,8 @@
 # Learn Search Engine Optimization
 
-> Search engine optimization (SEO) is the process of affecting the visibility of a website or a web page in a search engine's unpaid results - often referred to as "natural," "organic," or "earned" results. In general, the earlier (or higher ranked on the search results page), and more frequently a site appears in the search results list, the more visitors it will receive from the search engine's users. SEO may target different kinds of search, including image search, local search, video search, academic search, news search and industry-specific vertical search engines. - wikipedia
+> Search engine optimization (SEO) is the process of affecting the visibility of a website or a web page in a search engine's unpaid results &#8212; often referred to as "natural," "organic," or "earned" results. In general, the earlier (or higher ranked on the search results page), and more frequently a site appears in the search results list, the more visitors it will receive from the search engine's users. SEO may target different kinds of search, including image search, local search, video search, academic search, news search and industry-specific vertical search engines.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Search_engine_optimization)</cite>
 
 ##### General Learning:
 

--- a/learning/test.md
+++ b/learning/test.md
@@ -1,10 +1,16 @@
 # Learn JS Testing
 
-> **unit testing** - In computer programming, unit testing is a software testing method by which individual units of source code, sets of one or more computer program modules together with associated control data, usage procedures, and operating procedures, are tested to determine whether they are fit for use. Intuitively, one can view a unit as the smallest testable part of an application. - Wikipedia
+> **Unit Testing** - In computer programming, unit testing is a software testing method by which individual units of source code, sets of one or more computer program modules together with associated control data, usage procedures, and operating procedures, are tested to determine whether they are fit for use. Intuitively, one can view a unit as the smallest testable part of an application.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Unit_testing)</cite>
 >
-> **functional testing** - Functional testing is a quality assurance (QA) process and a type of black box testing that bases its test cases on the specifications of the software component under test. Functions are tested by feeding them input and examining the output, and internal program structure is rarely considered (not like in white-box testing). Functional testing usually describes what the system does. - Wikipedia
+> **Functional Testing** - Functional testing is a quality assurance (QA) process and a type of black box testing that bases its test cases on the specifications of the software component under test. Functions are tested by feeding them input and examining the output, and internal program structure is rarely considered (not like in white-box testing). Functional testing usually describes what the system does.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Functional_testing)</cite>
 >
-> **integration testing** - Integration testing (sometimes called integration and testing, abbreviated I&T) is the phase in software testing in which individual software modules are combined and tested as a group. It occurs after unit testing and before validation testing. Integration testing takes as its input modules that have been unit tested, groups them in larger aggregates, applies tests defined in an integration test plan to those aggregates, and delivers as its output the integrated system ready for system testing. - wikipedia
+> **Integration Testing** - Integration testing (sometimes called integration and testing, abbreviated I&T) is the phase in software testing in which individual software modules are combined and tested as a group. It occurs after unit testing and before validation testing. Integration testing takes as its input modules that have been unit tested, groups them in larger aggregates, applies tests defined in an integration test plan to those aggregates, and delivers as its output the integrated system ready for system testing.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Integration_testing)</cite>
 
 ##### General Learning:
 

--- a/learning/ui-design-patterns.md
+++ b/learning/ui-design-patterns.md
@@ -1,12 +1,20 @@
 # Learn User Interface/Interaction Design
 
-> **User interface design** User interface design (UI) or user interface engineering is the design of user interfaces for machines and software, such as computers, home appliances, mobile devices, and other electronic devices, with the focus on maximizing the user experience. The goal of user interface design is to make the user's interaction as simple and efficient as possible, in terms of accomplishing user goals (user-centered design). - wikipedia
+> **User Interface Design** - User interface design (UI) or user interface engineering is the design of user interfaces for machines and software, such as computers, home appliances, mobile devices, and other electronic devices, with the focus on maximizing the user experience. The goal of user interface design is to make the user's interaction as simple and efficient as possible, in terms of accomplishing user goals (user-centered design).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/User_interface_design)</cite>
 > 
-> **Interaction design pattern** A design pattern is a formal way of documenting a solution to a common design problem. The idea was introduced by the architect Christopher Alexander for use in urban planning and building architecture, and has been adapted for various other disciplines, including teaching and pedagogy, development organization and process, and software architecture and design. - wikipedia
+> **Interaction Design Pattern** - A design pattern is a formal way of documenting a solution to a common design problem. The idea was introduced by the architect Christopher Alexander for use in urban planning and building architecture, and has been adapted for various other disciplines, including teaching and pedagogy, development organization and process, and software architecture and design.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Design_pattern)</cite>
 >  
-> **User experience design** - User Experience Design (UXD or UED or XD) is the process of enhancing user satisfaction by improving the usability, accessibility, and pleasure provided in the interaction between the user and the product. User experience design encompasses traditional human–computer interaction (HCI) design, and extends it by addressing all aspects of a product or service as perceived by users. - wikipedia
+> **User Experience Design** - User Experience Design (UXD or UED or XD) is the process of enhancing user satisfaction by improving the usability, accessibility, and pleasure provided in the interaction between the user and the product. User experience design encompasses traditional human–computer interaction (HCI) design, and extends it by addressing all aspects of a product or service as perceived by users.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/User_experience_design)</cite>
 >  
-> **Human–computer interaction** Human–computer interaction (HCI) researches the design and use of computer technology, focusing particularly on the interfaces between people (users) and computers. Researchers in the field of HCI both observe the ways in which humans interact with computers and design technologies that lets humans interact with computers in novel ways. - wikipedia
+> **Human–Computer Interaction** - Human–computer interaction (HCI) researches the design and use of computer technology, focusing particularly on the interfaces between people (users) and computers. Researchers in the field of HCI both observe the ways in which humans interact with computers and design technologies that lets humans interact with computers in novel ways.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Human%E2%80%93computer_interaction)</cite>
 
 Minimally I'd suggest reading the following canonical texts on the matter so one can build proper user interfaces.
 

--- a/learning/version-control.md
+++ b/learning/version-control.md
@@ -1,6 +1,8 @@
 # Learn Version Control
 
-> A component of software configuration management, version control, also known as revision control or source control, is the management of changes to documents, computer programs, large web sites, and other collections of information. Changes are usually identified by a number or letter code, termed the "revision number," "revision level," or simply "revision." For example, an initial set of files is "revision 1." When the first change is made, the resulting set is "revision 2," and so on. Each revision is associated with a timestamp and the person making the change. Revisions can be compared, restored, and with some types of files, merged. - wikipedia
+> A component of software configuration management, version control, also known as revision control or source control, is the management of changes to documents, computer programs, large web sites, and other collections of information. Changes are usually identified by a number or letter code, termed the "revision number," "revision level," or simply "revision." For example, an initial set of files is "revision 1." When the first change is made, the resulting set is "revision 2," and so on. Each revision is associated with a timestamp and the person making the change. Revisions can be compared, restored, and with some types of files, merged.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Version_control)</cite>
 
 The current modern solution for version control is [Git](https://git-scm.com/). Learn it!
 

--- a/learning/web-api.md
+++ b/learning/web-api.md
@@ -4,7 +4,7 @@ The BOM and the DOM are not the only browser APIs that are made available on the
 
 ![](../images/web-api.png "http://www.evolutionoftheweb.com/")
 
-<cite>image source: <a href="http://www.evolutionoftheweb.com/">http://www.evolutionoftheweb.com/</a></cite>
+<cite>Image source: <a href="http://www.evolutionoftheweb.com/">http://www.evolutionoftheweb.com/</a></cite>
 
 You should be aware of and learn, where appropriate, web/browser APIs. A good tool to use to familiarize oneself with all of these APIs would be to investigate the [HTML5test.com results for the 5 most current browsers](https://html5test.com/compare/browser/chrome-44/firefox-40/ie-11/safari-9.0.html).
 

--- a/practice/fd-dev-for.md
+++ b/practice/fd-dev-for.md
@@ -23,7 +23,7 @@ These operating systems typically run on one or more of the following devices:
 
 ![](../images/fd-devs-for.jpeg "https://ams-ix.net/newsitems/87")
 
-<cite>image source: <a href="https://ams-ix.net/newsitems/87">https://ams-ix.net/newsitems/87</a></cite>
+<cite>Image source: <a href="https://ams-ix.net/newsitems/87">https://ams-ix.net/newsitems/87</a></cite>
 
 Generally speaking, front-end technologies can run on the aforementioned operating systems and devices using the following run time scenarios:
 

--- a/practice/making-fd.md
+++ b/practice/making-fd.md
@@ -2,7 +2,7 @@
 
 ![](../images/making-fd.png "http://cdn.skilledup.com/wp-content/uploads/2014/11/life-of-front-end-developer-infographic-Secondary.jpg")
 
-<cite>image source: <a href="http://cdn.skilledup.com/wp-content/uploads/2014/11/life-of-front-end-developer-infographic-Secondary.jpg">http://cdn.skilledup.com/wp-content/uploads/2014/11/life-of-front-end-developer-infographic-Secondary.jpg</a></cite>
+<cite>Image source: <a href="http://cdn.skilledup.com/wp-content/uploads/2014/11/life-of-front-end-developer-infographic-Secondary.jpg">http://cdn.skilledup.com/wp-content/uploads/2014/11/life-of-front-end-developer-infographic-Secondary.jpg</a></cite>
 
 How exactly does one become a front-end developer? Well, it's complicated. Still today you can't go to college and expect to graduate with a degree in front-end engineering. And, I rarely hear of or meet front-end developers who suffered through what is likely a deprecated computer science degree or graphic design degree to end up writing HTML, CSS, and JavaScript professionally. In fact, most of the people working on the front-end, even today, generally seem to be self taught and not traditionally trained as a programmer. Why is this the case?
 

--- a/practice/myth.md
+++ b/practice/myth.md
@@ -2,7 +2,7 @@
 
 ![](../images/full-stack.jpg "http://andyshora.com/full-stack-developers.html")
 
-<cite>image source: <a href="http://andyshora.com/full-stack-developers.html">http://andyshora.com/full-stack-developers.html</a></cite>
+<cite>Image source: <a href="http://andyshora.com/full-stack-developers.html">http://andyshora.com/full-stack-developers.html</a></cite>
 
 The roles required to design and develop a web solution require a deep skill set and vast experience in the area of visual design, UI/interaction design, front-end development, and back-end development. Any person (aka generalist or full-stack developer/designer) who can fill one or more of these 4 roles at a professional level is a rare exception to the rule.
 
@@ -10,7 +10,7 @@ Pragmatically, you should seek to be, or seek to hire, an expert in one of these
 
 ![](../images/stacks-change.jpg "http://andyshora.com/full-stack-developers.html")
 
-<cite>image source: <a href="http://andyshora.com/full-stack-developers.html">http://andyshora.com/full-stack-developers.html</a></cite>
+<cite>Image source: <a href="http://andyshora.com/full-stack-developers.html">http://andyshora.com/full-stack-developers.html</a></cite>
 
 
 

--- a/practice/salaries.md
+++ b/practice/salaries.md
@@ -6,7 +6,7 @@ An experienced front-end developer potentially can live wherever they want (i.e.
 
 ![](../images/front-end-salary.png "http://intersog.com/blog/chicago-tech-salary-guide-2015/")
 
-<cite>image source: <a href="http://intersog.com/blog/chicago-tech-salary-guide-2015/">http://intersog.com/blog/chicago-tech-salary-guide-2015/</a></cite>
+<cite>Image source: <a href="http://intersog.com/blog/chicago-tech-salary-guide-2015/">http://intersog.com/blog/chicago-tech-salary-guide-2015/</a></cite>
 
 
 

--- a/practice/skills.md
+++ b/practice/skills.md
@@ -2,7 +2,7 @@
 
 ![](../images/front-end-skills.png "http://blog.naustud.io/2015/06/baseline-for-modern-front-end-developers.html")
 
-<cite>image source: <a href="http://blog.naustud.io/2015/06/baseline-for-modern-front-end-developers.html">http://blog.naustud.io/2015/06/baseline-for-modern-front-end-developers.html</a></cite>
+<cite>Image source: <a href="http://blog.naustud.io/2015/06/baseline-for-modern-front-end-developers.html">http://blog.naustud.io/2015/06/baseline-for-modern-front-end-developers.html</a></cite>
 
 Basic to advanced HTML, CSS, DOM, JavaScript, HTTP/URL, and browser skills are assumed for any type of front-end developer. 
 

--- a/practice/tech-employed-by-fd.md
+++ b/practice/tech-employed-by-fd.md
@@ -2,7 +2,7 @@
 
 ![](../images/web-tech-employed.jpg "http://www.2n2media.com/compare-front-end-development-and-back-end-development")
 
-<cite> image source: <a href="http://www.2n2media.com/compare-front-end-development-and-back-end-development">http://www.2n2media.com/compare-front-end-development-and-back-end-development</a> </cite>
+<cite>Image source: <a href="http://www.2n2media.com/compare-front-end-development-and-back-end-development">http://www.2n2media.com/compare-front-end-development-and-back-end-development</a> </cite>
 
 The following web technologies are employed by front-end developers:
 
@@ -20,7 +20,9 @@ These technologies are defined below with the relevant documentation and specifi
 
 ##### Hyper Text Markup Language (aka HTML)
 
-> HyperText Markup Language, commonly referred to as HTML, is the standard markup language used to create web pages. Web browsers can read HTML files and render them into visible or audible web pages. HTML describes the structure of a website semantically along with cues for presentation, making it a markup language, rather than a programming language. - wikipedia.org
+> HyperText Markup Language, commonly referred to as HTML, is the standard markup language used to create web pages. Web browsers can read HTML files and render them into visible or audible web pages. HTML describes the structure of a website semantically along with cues for presentation, making it a markup language, rather than a programming language.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/HTML)</cite>
 
 Most relevant specifications / documentation:
 
@@ -34,7 +36,9 @@ Most relevant specifications / documentation:
 
 ##### Cascading Style Sheets (aka CSS)
 
-> Cascading Style Sheets (CSS) is a style sheet language used for describing the look and formatting of a document written in a markup language. Although most often used to change the style of web pages and user interfaces written in HTML and XHTML, the language can be applied to any kind of XML document, including plain XML, SVG and XUL. Along with HTML and JavaScript, CSS is a cornerstone technology used by most websites to create visually engaging webpages, user interfaces for web applications, and user interfaces for many mobile applications. - wikipedia.org
+> Cascading Style Sheets (CSS) is a style sheet language used for describing the look and formatting of a document written in a markup language. Although most often used to change the style of web pages and user interfaces written in HTML and XHTML, the language can be applied to any kind of XML document, including plain XML, SVG and XUL. Along with HTML and JavaScript, CSS is a cornerstone technology used by most websites to create visually engaging webpages, user interfaces for web applications, and user interfaces for many mobile applications.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Cascading_Style_Sheets)</cite>
 
 Most relevant specifications / documentation:
 
@@ -45,7 +49,9 @@ Most relevant specifications / documentation:
 
 ##### Document Object Model (aka DOM)
 
-> The Document Object Model (DOM) is a cross-platform and language-independent convention for representing and interacting with objects in HTML, XHTML, and XML documents. The nodes of every document are organized in a tree structure, called the DOM tree. Objects in the DOM tree may be addressed and manipulated by using methods on the objects. The public interface of a DOM is specified in its application programming interface (API). - wikipedia.org
+> The Document Object Model (DOM) is a cross-platform and language-independent convention for representing and interacting with objects in HTML, XHTML, and XML documents. The nodes of every document are organized in a tree structure, called the DOM tree. Objects in the DOM tree may be addressed and manipulated by using methods on the objects. The public interface of a DOM is specified in its application programming interface (API).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Document_Object_Model)</cite>
 
 Most relevant specifications / documentation:
 
@@ -55,7 +61,9 @@ Most relevant specifications / documentation:
 
 ##### JavaScript Programming Language (aka: ECMAScript 6, ES6, JavaScript 2015)
 
-> JavaScript is a high level, dynamic, untyped, and interpreted programming language. It has been standardized in the ECMAScript language specification. Alongside HTML and CSS, it is one of the three essential technologies of World Wide Web content production; the majority of websites employ it and it is supported by all modern web browsers without plug-ins. JavaScript is prototype-based with first-class functions, making it a multi-paradigm language, supporting object-oriented, imperative, and functional programming styles. It has an API for working with text, arrays, dates and regular expressions, but does not include any I/O, such as networking, storage or graphics facilities, relying for these upon the host environment in which it is embedded. - wikipedia.org
+> JavaScript is a high level, dynamic, untyped, and interpreted programming language. It has been standardized in the ECMAScript language specification. Alongside HTML and CSS, it is one of the three essential technologies of World Wide Web content production; the majority of websites employ it and it is supported by all modern web browsers without plug-ins. JavaScript is prototype-based with first-class functions, making it a multi-paradigm language, supporting object-oriented, imperative, and functional programming styles. It has an API for working with text, arrays, dates and regular expressions, but does not include any I/O, such as networking, storage or graphics facilities, relying for these upon the host environment in which it is embedded.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JavaScript)</cite>
 
 Most relevant specifications / documentation:
 
@@ -63,7 +71,9 @@ Most relevant specifications / documentation:
 
 ##### Web APIs (aka HTML5 and friends)
 
-> When writing code for the Web using JavaScript, there are a great many APIs available. Below is a list of all the interfaces (that is, types of objects) that you may be able to use while developing your Web app or site. - Mozilla
+> When writing code for the Web using JavaScript, there are a great many APIs available. Below is a list of all the interfaces (that is, types of objects) that you may be able to use while developing your Web app or site.
+
+><cite>&#8212; [Mozilla](https://developer.mozilla.org/en-US/docs/Web/API)</cite>
 
 Most relevant documentation:
 
@@ -71,7 +81,9 @@ Most relevant documentation:
 
 ##### Hypertext Transfer Protocol (aka HTTP)
 
-> The Hypertext Transfer Protocol (HTTP) is an application protocol for distributed, collaborative, hypermedia information systems. HTTP is the foundation of data communication for the World Wide Web. - wikipedia.org
+> The Hypertext Transfer Protocol (HTTP) is an application protocol for distributed, collaborative, hypermedia information systems. HTTP is the foundation of data communication for the World Wide Web.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)</cite>
 
 Most relevant specifications:
 
@@ -80,7 +92,9 @@ Most relevant specifications:
 
 ##### Uniform Resource Locators (aka URL)
 
-> A uniform resource locator (URL) (also called a web address) is a reference to a resource that specifies the location of the resource on a computer network and a mechanism for retrieving it. A URL is a specific type of uniform resource identifier (URI),[3] although many people use the two terms interchangeably. A URL implies the means to access an indicated resource, which is not true of every URI.[4][5] URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications. - wikipedia.org
+> A uniform resource locator (URL) (also called a web address) is a reference to a resource that specifies the location of the resource on a computer network and a mechanism for retrieving it. A URL is a specific type of uniform resource identifier (URI), although many people use the two terms interchangeably. A URL implies the means to access an indicated resource, which is not true of every URI. URLs occur most commonly to reference web pages (http), but are also used for file transfer (ftp), email (mailto), database access (JDBC), and many other applications.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Uniform_Resource_Locator)</cite>
 
 Most relevant specifications:
 
@@ -89,7 +103,9 @@ Most relevant specifications:
 
 ##### JavaScript Object Notation (aka JSON)
 
-> JSON, sometimes JavaScript Object Notation, is an open standard format that uses human-readable text to transmit data objects consisting of attribute–value pairs. It is the primary data format used for asynchronous browser/server communication (AJAJ), largely replacing XML (used by AJAX). Although originally derived from the JavaScript scripting language, JSON is a language-independent data format. Code for parsing and generating JSON data is readily available in many programming languages. The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json. - wikipedia.org
+> c It is the primary data format used for asynchronous browser/server communication (AJAJ), largely replacing XML (used by AJAX). Although originally derived from the JavaScript scripting language, JSON is a language-independent data format. Code for parsing and generating JSON data is readily available in many programming languages. The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JSON)</cite>
 
 Most relevant specifications:
 
@@ -99,7 +115,9 @@ Most relevant specifications:
 
 ##### Web Content Accessibility Guidelines (aka WCAG) & Accessible Rich Internet Applications (aka ARIA)
 
-> Accessibility refers to the design of products, devices, services, or environments for people with disabilities. The concept of accessible design ensures both “direct access” (i.e., unassisted) and "indirect access" meaning compatibility with a person's assistive technology (for example, computer screen readers). - wikipedia.org
+> Accessibility refers to the design of products, devices, services, or environments for people with disabilities. The concept of accessible design ensures both “direct access” (i.e., unassisted) and "indirect access" meaning compatibility with a person's assistive technology (for example, computer screen readers).
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Accessibility)</cite>
 
 * [Accessible Rich Internet Applications (WAI-ARIA) Current Status](http://www.w3.org/standards/techs/aria#w3c_all)
 * [Web Accessibility Initiative (WAI)](http://www.w3.org/WAI/)

--- a/tools.md
+++ b/tools.md
@@ -8,7 +8,7 @@ Note that just because a tool is listed, or a category of tools is documented, t
 
 ![](images/spectrum.png "https://medium.com/@withinsight1/the-front-end-spectrum-c0f30998c9f0")
 
-<cite>image source: <a href="https://medium.com/@withinsight1/the-front-end-spectrum-c0f30998c9f0">https://medium.com/@withinsight1/the-front-end-spectrum-c0f30998c9f0</a></cite>
+<cite>Image source: <a href="https://medium.com/@withinsight1/the-front-end-spectrum-c0f30998c9f0">https://medium.com/@withinsight1/the-front-end-spectrum-c0f30998c9f0</a></cite>
 
 
 

--- a/tools/code-editor.md
+++ b/tools/code-editor.md
@@ -1,6 +1,8 @@
 # Learn Code Editors
 
-> A source code editor is a text editor program designed specifically for editing source code of computer programs by programmers. It may be a standalone application or it may be built into an integrated development environment (IDE) or web browser. Source code editors are the most fundamental programming tool, as the fundamental job of programmers is to write and edit source code. - Wikipedia
+> A source code editor is a text editor program designed specifically for editing source code of computer programs by programmers. It may be a standalone application or it may be built into an integrated development environment (IDE) or web browser. Source code editors are the most fundamental programming tool, as the fundamental job of programmers is to write and edit source code.
+
+><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/Source_code_editor)</cite>
 
 Front-end code can minimally be edited with a simple text editing application like Notepad or TextEdit. But, most front-end practitioners use a code editor specifically design for editing a programming language.
 

--- a/tools/css.md
+++ b/tools/css.md
@@ -18,7 +18,9 @@
 
 ##### CSS Reset:
 
-> A CSS Reset (or “Reset CSS”) is a short, often compressed (minified) set of CSS rules that resets the styling of all HTML elements to a consistent baseline. - [http://cssreset.com/](http://cssreset.com/what-is-a-css-reset/)
+> A CSS Reset (or “Reset CSS”) is a short, often compressed (minified) set of CSS rules that resets the styling of all HTML elements to a consistent baseline.
+
+><cite>&#8212; [cssreset.com](http://cssreset.com/what-is-a-css-reset/)</cite>
 
 * [Eric Meyer’s “Reset CSS” 2.0](http://meyerweb.com/eric/tools/css/reset/)
 * [Normalize](https://necolas.github.io/normalize.css/)

--- a/what-is-a-FD.md
+++ b/what-is-a-FD.md
@@ -4,7 +4,7 @@ A front-end developer architects and develops websites and applications using we
 
 ![](images/what-is-front-end-dev.png "https://www.upwork.com/hiring/development/front-end-developer/")
 
-<cite>image source: <a href="https://www.upwork.com/hiring/development/front-end-developer/">https://www.upwork.com/hiring/development/front-end-developer/</a></cite>
+<cite>Image source: <a href="https://www.upwork.com/hiring/development/front-end-developer/">https://www.upwork.com/hiring/development/front-end-developer/</a></cite>
 
 Typically, a person enters into the field of front-end development by learning to develop HTML, CSS, and JS code, which runs in a [web browser](https://en.wikipedia.org/wiki/Web_browser), [headless browser](https://en.wikipedia.org/wiki/Headless_browser), [webview](http://developer.telerik.com/featured/what-is-a-webview/), or as compilation input for a native runtime environment. The four run times scenarios are explained below.
 


### PR DESCRIPTION
I noticed two accessibility link resources had the same name. I added an additional piece to the link title (Google, WAI) to differentiate for readers. I also applied an em dash (—) to use with the Wikipedia citation (following citation punctuation standards) and linked to the original Wikipedia resource.
