### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Part three briefly explains and identifies tools of the trade.
 
 **Read Online At**: 
 
-* [frontendhandbook.com](http://www.frontendhandbook.com/)
+* [frontendhandbook.com](https://www.frontendhandbook.com/)
  
 **Download a .pdf, .epub, or .mobi File From**: 
 
@@ -43,7 +43,7 @@ Part three briefly explains and identifies tools of the trade.
 
 ***
 
-<a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/">Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License</a>.
+<a rel="license" href="https://creativecommons.org/licenses/by-nc-nd/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/3.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/3.0/">Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License</a>.
 
 
 


### PR DESCRIPTION
This Pull Request changes some :link: to be :closed_lock_with_key:

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://creativecommons.org/licenses/by-nc-nd/3.0/ | https://creativecommons.org/licenses/by-nc-nd/3.0/ 
http://www.frontendhandbook.com/ | https://www.frontendhandbook.com/ 
