### PR TITLE
Update URL to Beautiful Web Type

### DIFF
--- a/learning/fonts.md
+++ b/learning/fonts.md
@@ -13,7 +13,7 @@
 ##### General Learning:
 
 * [A Comprehensive Guide to Font Loading Strategies](https://www.zachleat.com/web/comprehensive-webfonts/) [read]
-* [Beautiful Web Type a Showcase of the Best Typefaces from the Google Web Fonts Directory](http://hellohappy.org/beautiful-web-type/) [read]
+* [Beautiful Web Type a Showcase of the Best Typefaces from the Google Web Fonts Directory](https://beautifulwebtype.com) [read]
 * [Quick Guide to Webfonts via @font-face](http://www.html5rocks.com/en/tutorials/webfonts/quick/) [read]
 * [Responsive Typography](https://frontendmasters.com/courses/responsive-typography/) [watch][$]
 * [Typography for the Web](http://www.pluralsight.com/courses/typography-for-web-1790) [watch][$]


### PR DESCRIPTION
The Beautiful Web Type project has been moved to a new URL. The previous domain was purchased by a spammer who is using it to link to their essay writing services.